### PR TITLE
Add Next.js bus news form example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Proyecto ONVIA – Pruebas con Codex
+
+## Instrucciones de desarrollo
+
+Este proyecto ahora incluye un ejemplo básico de Next.js con Tailwind CSS.
+Para probarlo en tu entorno local, ejecuta:
+
+```bash
+npm install
+npm run dev
+```
+
+Luego abre `http://localhost:3000` en el navegador.

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Novedades de Buses',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="es">
+      <body className="min-h-screen bg-gray-100 p-4">{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,10 @@
+import BusNewsForm from '../components/BusNewsForm';
+
+export default function HomePage() {
+  return (
+    <main className="container mx-auto max-w-xl">
+      <h1 className="text-2xl font-bold mb-4">Cargar Novedad de Bus</h1>
+      <BusNewsForm />
+    </main>
+  );
+}

--- a/components/BusNewsForm.tsx
+++ b/components/BusNewsForm.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState, ChangeEvent, FormEvent } from 'react';
+
+interface PreviewData {
+  image?: string;
+  category: string;
+  comment: string;
+  date: string;
+}
+
+const categories = [
+  'Gráfica externa',
+  'Gráfica interna',
+  'Chapería',
+  'Pintura',
+  'Interiores',
+  'Limpieza interior',
+  'Desperfectos generales',
+];
+
+export default function BusNewsForm() {
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [category, setCategory] = useState(categories[0]);
+  const [comment, setComment] = useState('');
+  const [preview, setPreview] = useState<PreviewData | null>(null);
+
+  const currentDate = new Date().toLocaleString();
+
+  const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setImageFile(file);
+      setImagePreview(URL.createObjectURL(file));
+    } else {
+      setImageFile(null);
+      setImagePreview(null);
+    }
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    setPreview({
+      image: imagePreview ?? undefined,
+      category,
+      comment,
+      date: currentDate,
+    });
+  };
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit} className="space-y-4 bg-white p-4 rounded shadow">
+        <div>
+          <label className="block font-medium mb-1">Imagen</label>
+          <input type="file" accept="image/*" onChange={handleImageChange} />
+          {imagePreview && (
+            <img src={imagePreview} alt="Preview" className="mt-2 h-32 object-contain" />
+          )}
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Categoría</label>
+          <select
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            className="border rounded p-2 w-full"
+          >
+            {categories.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Comentario</label>
+          <textarea
+            className="border rounded p-2 w-full"
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            rows={3}
+          />
+        </div>
+        <div>
+          <label className="block font-medium mb-1">Fecha y Hora</label>
+          <input
+            type="text"
+            value={currentDate}
+            disabled
+            className="border rounded p-2 w-full bg-gray-100"
+          />
+        </div>
+        <button
+          type="submit"
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+        >
+          Cargar novedad
+        </button>
+      </form>
+
+      {preview && (
+        <div className="mt-6 p-4 bg-white rounded shadow">
+          <h2 className="text-xl font-semibold mb-2">Previsualización</h2>
+          {preview.image && (
+            <img src={preview.image} alt="Preview" className="mb-2 h-40 object-contain" />
+          )}
+          <p className="font-medium">Categoría: {preview.category}</p>
+          <p className="font-medium">Fecha y Hora: {preview.date}</p>
+          <p className="whitespace-pre-wrap">{preview.comment}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "bus-news",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.21",
+    "tailwindcss": "3.3.3",
+    "typescript": "5.2.2"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize a minimal Next.js 14 + Tailwind project
- implement `BusNewsForm` component for bus incident reporting
- set up app router pages and global styles
- document dev instructions in README

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b1010f5f08327ac7d5b6438c371ad